### PR TITLE
Return URL in response in case of no Redirect

### DIFF
--- a/goreq.go
+++ b/goreq.go
@@ -325,6 +325,11 @@ func (r Request) Do() (*Response, error) {
 	}
 
 	res, err := client.Do(req)
+	//If resUri is blank, then we didn't have any redirection. Return original URL
+	if resUri == ""  {
+		resUri = req.URL.String()
+	}
+	
 	if timer != nil {
 		timer.Stop()
 	}


### PR DESCRIPTION
Return URL in response in case of no Redirect. Currently it returns a blank URL. This just checks if the url is blank then it returns the request url irrespective of the error or good result
